### PR TITLE
Fix link to Prebuilt UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please note: these demos are intended as educational resources for using the Dai
 
 Examples that showcase the Daily CallObject using our Javascript library
 
-## [Prebuilt UI](./dailyjs/prebuilt-ui)
+## [Prebuilt UI](./prebuilt-ui)
 
 Examples that showcase using and customizing the Daily Prebuilt UI
 


### PR DESCRIPTION
Current link for Prebuilt UI - https://github.com/daily-demos/examples/blob/main/dailyjs/prebuilt-ui redirects to 404
removing dailyjs and just going to https://github.com/daily-demos/examples/tree/main/prebuilt-ui works