### PR TITLE
Fix README links for basic-call example

### DIFF
--- a/dailyjs/basic-call/README.md
+++ b/dailyjs/basic-call/README.md
@@ -35,16 +35,16 @@ yarn workspace @dailyjs/basic-call dev
 
 This demo puts to work the following [shared libraries](../shared):
 
-**[MediaProvider.js](../shared/contexts/MediaProvider.js)**
+**[MediaDeviceProvider.js](../shared/contexts/MediaDeviceProvider.js)**
 Convenience context that provides an interface to media devices throughout app
 
-**[useDevices.js](../shared/hooks/useDevices.js)**
+**[useDevices.js](../shared/contexts/useDevices.js)**
 Hook for managing the enumeration and status of client media devices)
 
 **[CallProvider.js](../shared/contexts/CallProvider.js)**
 Primary call context that manages Daily call state, participant state and call object interaction
 
-**[useCallMachine.js](../shared/hooks/useCallMachine.js)**
+**[useCallMachine.js](../shared/contexts/useCallMachine.js)**
 Abstraction hook that manages Daily call state and error handling
 
 **[ParticipantProvider.js](../shared/contexts/ParticipantProvider.js)**


### PR DESCRIPTION
These were 404ing since these files were moved/renamed. Alternatively, could just change it to read
> These examples re-use some common components, contexts, hooks and libraries. These can be found in the shared folder.
to match what's in [the main example README](https://github.com/daily-demos/examples/tree/main/dailyjs)
- ../shared/contexts/MediaProvider.js -> ../shared/contexts/MediaDeviceProvider.js
- ../shared/hooks/useDevices.js -> ../shared/contexts/useDevices.js
- ../shared/hooks/useCallMachine.js -> ../shared/contexts/useCallMachine.js