### PR TITLE
Address new media element limits on >= Chrome 92

### DIFF
--- a/dailyjs/shared/components/Audio/Audio.js
+++ b/dailyjs/shared/components/Audio/Audio.js
@@ -1,5 +1,11 @@
 /**
  * Audio
+ * ---
+ * When working with audio elements it's very important to avoid mutating
+ * the DOM elements as much as possible to avoid audio pops and crackles.
+ * This component addresses to known browser quirks; Safari autoplay
+ * and Chrome's maximum media elements. On Chrome we add all audio tracks
+ * into into a single audio node using the CombinedAudioTrack component
  */
 import React, { useEffect, useMemo } from 'react';
 import { useTracks } from '@dailyjs/shared/contexts/TracksProvider';

--- a/dailyjs/shared/components/Audio/AudioTrack.js
+++ b/dailyjs/shared/components/Audio/AudioTrack.js
@@ -1,0 +1,45 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const AudioTrack = React.memo(
+  ({ track }) => {
+    const audioRef = useRef(null);
+
+    useEffect(() => {
+      if (!audioRef.current) return false;
+      let playTimeout;
+
+      const handleCanPlay = () => {
+        playTimeout = setTimeout(() => {
+          console.log('Unable to autoplay audio element');
+        }, 1500);
+      };
+      const handlePlay = () => {
+        clearTimeout(playTimeout);
+      };
+      audioRef.current.addEventListener('canplay', handleCanPlay);
+      audioRef.current.addEventListener('play', handlePlay);
+      audioRef.current.srcObject = new MediaStream([track]);
+
+      const audioEl = audioRef.current;
+
+      return () => {
+        audioEl?.removeEventListener('canplay', handleCanPlay);
+        audioEl?.removeEventListener('play', handlePlay);
+      };
+    }, [track]);
+
+    return track ? (
+      <audio autoPlay playsInline ref={audioRef}>
+        <track kind="captions" />
+      </audio>
+    ) : null;
+  },
+  () => true
+);
+
+AudioTrack.propTypes = {
+  track: PropTypes.object,
+};
+
+export default AudioTrack;

--- a/dailyjs/shared/components/Audio/CombinedAudioTrack.js
+++ b/dailyjs/shared/components/Audio/CombinedAudioTrack.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useDeepCompareEffect, useDeepCompareMemo } from 'use-deep-compare';
+
+const CombinedAudioTrack = ({ tracks }) => {
+  const audioEl = useRef(null);
+
+  useEffect(() => {
+    if (!audioEl) return;
+    audioEl.current.srcObject = new MediaStream();
+  }, []);
+
+  const trackIds = useDeepCompareMemo(
+    () => Object.values(tracks).map((t) => t?.persistentTrack?.id),
+    [tracks]
+  );
+
+  useDeepCompareEffect(() => {
+    const audio = audioEl.current;
+    if (!audio || !audio.srcObject) return;
+
+    const stream = audio.srcObject;
+    const allTracks = Object.values(tracks);
+
+    allTracks.forEach((track) => {
+      const persistentTrack = track?.persistentTrack;
+      if (persistentTrack) {
+        persistentTrack.addEventListener(
+          'ended',
+          (ev) => stream.removeTrack(ev.target),
+          { once: true }
+        );
+        stream.addTrack(persistentTrack);
+      }
+    });
+
+    audio.load();
+
+    if (
+      stream
+        .getAudioTracks()
+        .some((t) => t.enabled && t.readyState === 'live') &&
+      audio.paused
+    ) {
+      audio.play();
+    }
+  }, [tracks, trackIds]);
+
+  return (
+    <audio autoPlay playsInline ref={audioEl}>
+      <track kind="captions" />
+    </audio>
+  );
+};
+
+CombinedAudioTrack.propTypes = {
+  tracks: PropTypes.object,
+};
+
+export default CombinedAudioTrack;

--- a/dailyjs/shared/components/Tile/Video/Video.js
+++ b/dailyjs/shared/components/Tile/Video/Video.js
@@ -1,31 +1,46 @@
-import React, { forwardRef, memo, useEffect } from 'react';
+import React, { useMemo, forwardRef, memo, useEffect } from 'react';
+import Bowser from 'bowser';
 import PropTypes from 'prop-types';
 import { shallowEqualObjects } from 'shallow-equal';
 
 export const Video = memo(
-  forwardRef(({ videoTrack, ...rest }, videoEl) => {
+  forwardRef(({ participantId, videoTrack, ...rest }, videoEl) => {
+    // See: https://bugs.chromium.org/p/chromium/issues/detail?id=1232649
+    const isChrome92 = useMemo(() => {
+      const { browser, platform, os } = Bowser.parse(navigator.userAgent);
+      return (
+        browser.name === 'Chrome' &&
+        parseInt(browser.version, 10) >= 92 &&
+        (platform.type === 'desktop' || os.name === 'Android')
+      );
+    }, []);
+
+    /**
+     * Effect: Umount
+     * Note: nullify src to ensure media object is not counted
+     */
+    useEffect(() => {
+      const video = videoEl.current;
+      if (!video) return false;
+      // clean up when video renders for different participant
+      video.srcObject = null;
+      if (isChrome92) video.load();
+      return () => {
+        // clean up when unmounted
+        video.srcObject = null;
+        if (isChrome92) video.load();
+      };
+    }, [videoEl, isChrome92, participantId]);
+
     /**
      * Effect: mount source
      */
     useEffect(() => {
-      if (!videoEl?.current) return;
-      // eslint-disable-next-line no-param-reassign
-      videoEl.current.srcObject = new MediaStream([videoTrack]);
-    }, [videoEl, videoTrack]);
-
-    /**
-     * Effect: unmount
-     */
-    useEffect(
-      () => () => {
-        if (videoEl?.current?.srcObject) {
-          videoEl.current.srcObject.getVideoTracks().forEach((t) => t.stop());
-          // eslint-disable-next-line no-param-reassign
-          videoEl.current.srcObject = null;
-        }
-      },
-      [videoEl]
-    );
+      const video = videoEl.current;
+      if (!video || !videoTrack) return;
+      video.srcObject = new MediaStream([videoTrack]);
+      if (isChrome92) video.load();
+    }, [videoEl, isChrome92, videoTrack]);
 
     return <video autoPlay muted playsInline ref={videoEl} {...rest} />;
   }),
@@ -35,6 +50,7 @@ export const Video = memo(
 Video.propTypes = {
   videoTrack: PropTypes.any,
   mirrored: PropTypes.bool,
+  participantId: PropTypes.string,
 };
 
 export default Video;

--- a/dailyjs/shared/package.json
+++ b/dailyjs/shared/package.json
@@ -13,6 +13,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-portal": "^4.2.1",
     "shallow-equal": "^1.2.1",
     "use-deep-compare": "^1.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,7 +2800,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@15.7.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -2906,6 +2906,13 @@ react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-portal@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.1.tgz#12c1599238c06fb08a9800f3070bea2a3f78b1a6"
+  integrity sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-refresh@0.8.3:
   version "0.8.3"


### PR DESCRIPTION
This PR addresses changes introduced to Chrome >= 92 detailed [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1232649)

- [x] Combine all audio tracks into a single audio element
- [x] Remove all srcObjects when unmounting media elements