### PR TITLE
DEV-1052 Fix: undefined flying emojis in examples repo

### DIFF
--- a/custom/shared/package.json
+++ b/custom/shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@daily-co/daily-js": "0.19.0",
+    "@daily-co/daily-js": "0.21.0",
     "bowser": "^2.11.0",
     "classnames": "^2.3.1",
     "debounce": "^1.2.1",


### PR DESCRIPTION
Hello! 

When I run the repo locally as is, I see undefined for my flying emojis. Here's a [Loom recording](https://www.loom.com/share/4e7ed2d509d54ccc9bbd4ae6dbb23bf4), and the steps to reproduce: 

1. Run the flying-emojis example locally, on the `main` branch. 
2. Join in two separate tabs in the same room; doesn't matter if you join as an owner or not. 
3. Make sure you can see both instances. 
4. Try to send a flying emoji. You should be able to see it "locally", but the "remote" tab will see "undefined".

While I could see this as a very-funny-to-me feature not a bug, I pushed up a quick fix on a new branch that I think solves this. Here's the approach: 

- On `main`, we're asking the handleNewFlyingEmoji f(n) to do the same thing when it receives an emoji string as a local participant or when it receives an event object as a remote participant
- This PR adds a new handler that passes the e.data to the original function

I also did some renaming of functions to mach the mental model that helped me sort this. Please let me know of any feedback on that. 

Thank you for your review!

Kimberlee 