### PR TITLE
Add network indicator to basic-call example

### DIFF
--- a/custom/shared/components/NetworkStrength/NetworkStrength.js
+++ b/custom/shared/components/NetworkStrength/NetworkStrength.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ReactComponent as IconSignal } from '@custom/shared/icons/signal-sm.svg';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+export const NetworkStrength = ({ strength = 'good' }) => {
+  const cx = classNames('network-strength', strength);
+
+  return (
+    <div className={cx}>
+      <IconSignal />
+      <style jsx>{`
+        .network-strength {
+          padding: var(--spacing-xxxxs);
+          border-radius: 50%;
+        }
+        .good {
+          background: var(--green-dark);
+        }
+        .low {
+          background: var(--secondary-dark);
+        }
+        .very-low {
+          background: var(--red-dark);
+        }
+      `}
+      </style>
+    </div>
+  )
+};
+
+NetworkStrength.propTypes = {
+  strength: PropTypes.oneOf(['very-low', 'low', 'good'])
+};
+
+export default NetworkStrength;

--- a/custom/shared/components/NetworkStrength/index.js
+++ b/custom/shared/components/NetworkStrength/index.js
@@ -1,0 +1,1 @@
+export { NetworkStrength as default } from './NetworkStrength';

--- a/custom/shared/components/Tile/Tile.js
+++ b/custom/shared/components/Tile/Tile.js
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useState, useRef } from 'react';
+import NetworkStrength from '@custom/shared/components/NetworkStrength';
 import useVideoTrack from '@custom/shared/hooks/useVideoTrack';
 import { ReactComponent as IconMicMute } from '@custom/shared/icons/mic-off-sm.svg';
 import classNames from 'classnames';
@@ -19,12 +20,15 @@ export const Tile = memo(
     videoFit = 'contain',
     aspectRatio = DEFAULT_ASPECT_RATIO,
     onVideoResize,
+    networkStrength = null,
     ...props
   }) => {
     const videoTrack = useVideoTrack(participant);
     const videoRef = useRef(null);
     const tileRef = useRef(null);
     const [tileWidth, setTileWidth] = useState(0);
+
+    const [displayNetwork, setDisplayNetwork] = useState(false);
 
     /**
      * Effect: Resize
@@ -77,6 +81,15 @@ export const Tile = memo(
       };
     }, [tileRef]);
 
+    useEffect(() => {
+      tileRef.current.addEventListener('mouseenter', () => setDisplayNetwork(true));
+      tileRef.current.addEventListener('mouseleave', () => setDisplayNetwork(false))
+      return () => {
+        tileRef.current.removeEventListener('mouseenter', () => setDisplayNetwork(true));
+        tileRef.current.removeEventListener('mouseleave', () => setDisplayNetwork(false))
+      };
+    }, [tileRef]);
+
     const cx = classNames('tile', videoFit, {
       mirrored,
       avatar: showAvatar && !videoTrack,
@@ -88,6 +101,11 @@ export const Tile = memo(
     return (
       <div ref={tileRef} className={cx} {...props}>
         <div className="content">
+          {displayNetwork && (
+            <div className="network-quality">
+              <NetworkStrength strength={networkStrength} />
+            </div>
+          )}
           {showName && (
             <div className="name">
               {participant.isMicMuted && !participant.isScreenShare && (
@@ -160,6 +178,19 @@ export const Tile = memo(
 
           .tile.small .name {
             font-size: 12px;
+          }
+          
+          .tile .network-quality {
+            position: absolute;
+            top: 0;
+            display: flex;
+            align-items: center;
+            left: 0;
+            z-index: 2;
+            line-height: 1;
+            color: white;
+            padding: var(--spacing-xxxxs);
+            gap: var(--spacing-xxs);
           }
 
           .tile :global(video) {

--- a/custom/shared/contexts/participantsState.js
+++ b/custom/shared/contexts/participantsState.js
@@ -33,6 +33,7 @@ const initialParticipantsState = {
       lastActiveDate: null,
       micMutedByHost: false,
       name: '',
+      user_id: '',
     },
   ],
   screens: [],
@@ -85,6 +86,7 @@ function getNewParticipant(participant) {
     lastActiveDate: null,
     micMutedByHost: audio?.off?.byRemoteRequest,
     name: participant.user_name,
+    user_id: participant.user_id,
   };
 }
 
@@ -116,6 +118,7 @@ function getUpdatedParticipant(participant, participants) {
     isRecording: !!participant.record,
     micMutedByHost: audio?.off?.byRemoteRequest,
     name: participant.user_name,
+    user_id: participant.user_id,
   };
 }
 

--- a/custom/shared/hooks/useSharedState.js
+++ b/custom/shared/hooks/useSharedState.js
@@ -1,0 +1,123 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallState } from '../contexts/CallProvider';
+
+// @params initialValues - initial values of the shared state.
+// @params broadcast - share the state with the other participants whenever the state changes.
+export const useSharedState = ({ initialValues = {}, broadcast = true }) => {
+  const { callObject } = useCallState();
+  const stateRef = useRef(null);
+  const requestIntervalRef = useRef(null);
+
+  const [state, setState] = useState({
+    sharedState: initialValues,
+    setAt: undefined,
+  });
+
+  // handling the app-message event, to check if the state is being shared.
+  const handleAppMessage = useCallback(
+    event => {
+      // two types of events -
+      // 1. Request shared state (request-shared-state)
+      // 2. Set shared state (set-shared-state)
+      switch (event.data?.message?.type) {
+        // if we receive a request-shared-state message type, we check if the user has any previous state,
+        // if yes, we will send the shared-state to everyone in the call.
+        case 'request-shared-state':
+          if (!stateRef.current.setAt) return;
+          callObject.sendAppMessage(
+            {
+              message: {
+                type: 'set-shared-state',
+                value: stateRef.current,
+              },
+            },
+            '*',
+          );
+          break;
+        // if we receive a set-shared-state message type then, we check the state timestamp with the local one and
+        // we set the latest shared-state values into the local state.
+        case 'set-shared-state':
+          clearInterval(requestIntervalRef.current);
+          if (
+            stateRef.current.setAt &&
+            new Date(stateRef.current.setAt) > new Date(event.data.message.value.setAt)
+          )
+            return;
+          setState(event.data.message.value);
+          break;
+      }
+    },
+    [stateRef, callObject],
+  );
+
+  // whenever local user joins, we randomly pick a participant from the call and request him for the state.
+  const handleJoinedMeeting = useCallback(() => {
+    const randomDelay = 1000 + Math.ceil(1000 * Math.random());
+
+    requestIntervalRef.current = setInterval(() => {
+      const callObjectParticipants = callObject.participants();
+      const participants = Object.values(callObjectParticipants);
+      const localParticipant = callObjectParticipants.local;
+
+      if (participants.length > 1) {
+        const remoteParticipants = participants.filter((p) =>
+          !p.local && new Date(p.joined_at) < new Date(localParticipant.joined_at)
+        );
+        const randomPeer = remoteParticipants[Math.floor(Math.random() * remoteParticipants.length)];
+        callObject.sendAppMessage(
+          {
+            message: {
+              type: 'request-shared-state',
+            },
+          },
+          randomPeer.user_id,
+        );
+      } else clearInterval(requestIntervalRef.current);
+    }, randomDelay);
+
+    return () => clearInterval(requestIntervalRef.current);
+  }, [callObject]);
+
+  useEffect(() => {
+    if (!callObject) return;
+    callObject.on('app-message', handleAppMessage);
+    callObject.on('joined-meeting', handleJoinedMeeting);
+    return () => {
+      callObject.off('app-message', handleAppMessage);
+      callObject.off('joined-meeting', handleJoinedMeeting);
+    }
+  }, [callObject, handleAppMessage, handleJoinedMeeting]);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  // setSharedState function takes in the state values :-
+  // 1. shares the state with everyone in the call.
+  // 2. set the state for the local user.
+  const setSharedState = useCallback(
+    values => {
+      setState((state) => {
+        const currentValues = typeof values === 'function' ? values(state.sharedState) : values;
+        const stateObj = { ...state, sharedState: currentValues, setAt: new Date() };
+        // if broadcast is true, we send the state to everyone in the call whenever the state changes.
+        if (broadcast) {
+          callObject.sendAppMessage(
+            {
+              message: {
+                type: 'set-shared-state',
+                value: stateObj,
+              },
+            },
+            '*',
+          );
+        }
+        return stateObj;
+      });
+
+    }, [broadcast, callObject],
+  );
+
+  // returns back the sharedState and the setSharedState function
+  return { sharedState: state.sharedState, setSharedState };
+};

--- a/custom/shared/icons/signal-sm.svg
+++ b/custom/shared/icons/signal-sm.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>signal_cellular_alt</title><g fill="none" class="nc-icon-wrapper"><path d="M17 4h3v16h-3V4zM5 14h3v6H5v-6zm6-5h3v11h-3V9z" fill="#ffffff"></path></g></svg>


### PR DESCRIPTION
This PR adds the network indicator to the basic call.

Used the `useSharedState` for sharing the participant's network state among them.