### PR TITLE
Add early return in case remote participant array is empty (useSharedState)

### DIFF
--- a/custom/shared/hooks/useSharedState.js
+++ b/custom/shared/hooks/useSharedState.js
@@ -72,6 +72,9 @@ export const useSharedState = ({ initialValues = {}, broadcast = true }) => {
             new Date(p.joined_at) < new Date(localParticipant.joined_at)
         );
 
+        // avoid sending message if no remote participants are available
+        if (remoteParticipants?.length === 0) return;
+
         const randomPeer =
           remoteParticipants[
             Math.floor(Math.random() * remoteParticipants.length)


### PR DESCRIPTION
Suggestion from tutorial review -- let's be a little more defensive in the off chance the array is empty while requesting shared state from a random peer. 