### PR TITLE
DEV-1123 Refactor: update lobby demo to use memoization

### DIFF
--- a/custom/shared/components/HairCheck/HairCheck.js
+++ b/custom/shared/components/HairCheck/HairCheck.js
@@ -140,6 +140,17 @@ export const HairCheck = () => {
         ) : (
           <span>Waiting for host to grant access</span>
         )}
+        <style jsx>{`
+          .waiting {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+          }
+
+          .waiting span {
+            margin-left: var(--spacing-xxs);
+          }
+        `}</style>
       </div>
     );
   }, [denied]);
@@ -327,16 +338,6 @@ export const HairCheck = () => {
             display: grid;
             grid-template-columns: 1fr auto;
             grid-column-gap: var(--spacing-xs);
-          }
-
-          .waiting {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-          }
-
-          .waiting span {
-            margin-left: var(--spacing-xxs);
           }
 
           .logo {

--- a/custom/shared/components/HairCheck/HairCheck.js
+++ b/custom/shared/components/HairCheck/HairCheck.js
@@ -32,8 +32,13 @@ import { useDeepCompareMemo } from 'use-deep-compare';
 export const HairCheck = () => {
   const { callObject, join } = useCallState();
   const { localParticipant } = useParticipants();
-  const { deviceState, camError, micError, isCamMuted, isMicMuted } =
-    useMediaDevices();
+  const {
+    deviceState,
+    camError,
+    micError,
+    isCamMuted,
+    isMicMuted,
+  } = useMediaDevices();
   const { openModal } = useUIState();
   const [waiting, setWaiting] = useState(false);
   const [joining, setJoining] = useState(false);
@@ -95,10 +100,9 @@ export const HairCheck = () => {
     [localParticipant]
   );
 
-  const isLoading = useMemo(
-    () => deviceState === DEVICE_STATE_LOADING,
-    [deviceState]
-  );
+  const isLoading = useMemo(() => deviceState === DEVICE_STATE_LOADING, [
+    deviceState,
+  ]);
 
   const hasError = useMemo(() => {
     if (
@@ -126,6 +130,39 @@ export const HairCheck = () => {
         return 'unknown';
     }
   }, [camError]);
+
+  const showWaitingMessage = useMemo(() => {
+    return (
+      <div className="waiting">
+        <Loader />
+        {denied ? (
+          <span>Call owner denied request</span>
+        ) : (
+          <span>Waiting for host to grant access</span>
+        )}
+      </div>
+    );
+  }, [denied]);
+
+  const showUsernameInput = useMemo(() => {
+    return (
+      <>
+        <TextInput
+          placeholder="Enter display name"
+          variant="dark"
+          disabled={joining}
+          value={userName}
+          onChange={(e) => setUserName(e.target.value)}
+        />
+        <Button
+          disabled={joining || userName.length < 3}
+          onClick={() => joinCall(userName)}
+        >
+          Join call
+        </Button>
+      </>
+    );
+  }, [userName, joinCall, joining, setUserName]);
 
   return (
     <>
@@ -174,34 +211,7 @@ export const HairCheck = () => {
             </div>
             {tileMemo}
           </div>
-          <footer>
-            {waiting ? (
-              <div className="waiting">
-                <Loader />
-                {denied ? (
-                  <span>Call owner denied request</span>
-                ) : (
-                  <span>Waiting for host to grant access</span>
-                )}
-              </div>
-            ) : (
-              <>
-                <TextInput
-                  placeholder="Enter display name"
-                  variant="dark"
-                  disabled={joining}
-                  value={userName}
-                  onChange={(e) => setUserName(e.target.value)}
-                />
-                <Button
-                  disabled={joining || userName.length < 3}
-                  onClick={() => joinCall(userName)}
-                >
-                  Join call
-                </Button>
-              </>
-            )}
-          </footer>
+          <footer>{waiting ? showWaitingMessage : showUsernameInput}</footer>
         </div>
 
         <style jsx>{`

--- a/custom/shared/contexts/WaitingRoomProvider.js
+++ b/custom/shared/contexts/WaitingRoomProvider.js
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -13,7 +14,6 @@ const WaitingRoomContext = createContext(null);
 export const WaitingRoomProvider = ({ children }) => {
   const { callObject } = useCallState();
   const [waitingParticipants, setWaitingParticipants] = useState([]);
-  const [multipleWaiting, setMultipleWaiting] = useState();
   const [showModal, setShowModal] = useState(false);
 
   const handleWaitingParticipantEvent = useCallback(() => {
@@ -32,8 +32,11 @@ export const WaitingRoomProvider = ({ children }) => {
         };
       })
     );
-    setMultipleWaiting(waiting.length > 1);
   }, [callObject]);
+
+  const multipleWaiting = useMemo(() => waitingParticipants.length > 1, [
+    waitingParticipants,
+  ]);
 
   useEffect(() => {
     if (waitingParticipants.length === 0) {

--- a/custom/shared/contexts/WaitingRoomProvider.js
+++ b/custom/shared/contexts/WaitingRoomProvider.js
@@ -13,6 +13,7 @@ const WaitingRoomContext = createContext(null);
 export const WaitingRoomProvider = ({ children }) => {
   const { callObject } = useCallState();
   const [waitingParticipants, setWaitingParticipants] = useState([]);
+  const [multipleWaiting, setMultipleWaiting] = useState();
   const [showModal, setShowModal] = useState(false);
 
   const handleWaitingParticipantEvent = useCallback(() => {
@@ -31,6 +32,7 @@ export const WaitingRoomProvider = ({ children }) => {
         };
       })
     );
+    setMultipleWaiting(waiting.length > 1);
   }, [callObject]);
 
   useEffect(() => {
@@ -97,6 +99,7 @@ export const WaitingRoomProvider = ({ children }) => {
         setShowModal,
         showModal,
         waitingParticipants,
+        multipleWaiting,
       }}
     >
       {children}


### PR DESCRIPTION
This PR addresses @jessmitch42's great feedback that refactoring this code with useMemo (similar to what we did in [Party Line](https://github.com/daily-demos/party-line/blob/980ccce8572883930f1144bf27975b7dbc461108/react/src/components/InCall.jsx#L33)), could help with readability in a future blog post. 

It adds a `multipleWaiting` variable to WaitingRoomProvider.js, and uses that value to determine which component to display in WaitingRoomNotification.js. 

The PR also makes a similar change in HairCheck.js for the waiting room message. 